### PR TITLE
Make navigation triangles clickable

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -25,7 +25,7 @@ function NavItem({ item, level, location }) {
 
   return (
     <li style={{ padding: 0 }}>
-      <div style={{ display: "flex", alignItems: "flex-start", margin: "0.25rem 0" }}>
+      <div style={{ display: "flex", alignItems: "center", margin: "0.25rem 0" }}>
         {hasChildren && (
           <button
             type="button"

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,5 @@
 import { Link, Outlet, useLocation } from "react-router-dom";
+import { useState } from "react";
 
 function NavLink({ to, label, location }) {
   return (
@@ -18,22 +19,35 @@ function NavLink({ to, label, location }) {
   );
 }
 
+function NavItem({ item, level, location }) {
+  const hasChildren = Array.isArray(item.children) && item.children.length > 0;
+  const [open, setOpen] = useState(false);
+
+  return (
+    <li style={{ padding: 0 }}>
+      <div style={{ display: "flex", alignItems: "flex-start", margin: "0.25rem 0" }}>
+        {hasChildren && (
+          <button
+            type="button"
+            className={`nav-toggle${open ? " open" : ""}`}
+            aria-label={open ? "Collapse submenu" : "Expand submenu"}
+            onClick={() => setOpen(!open)}
+          />
+        )}
+        <NavLink to={item.path} label={item.label} location={location} />
+      </div>
+      {hasChildren && open && (
+        <NavList items={item.children} level={level + 1} location={location} />
+      )}
+    </li>
+  );
+}
+
 function NavList({ items, level = 0, location }) {
   return (
     <ul className="nav-menu" style={{ margin: 0, paddingLeft: `${level}rem` }}>
       {items.map((item) => (
-        <li key={item.path || item.label} style={{ padding: 0 }}>
-          {item.children ? (
-            <details style={{ margin: "0.25rem 0" }}>
-              <summary className="nav-summary">
-                <NavLink to={item.path} label={item.label} location={location} />
-              </summary>
-              <NavList items={item.children} level={level + 1} location={location} />
-            </details>
-          ) : (
-            <NavLink to={item.path} label={item.label} location={location} />
-          )}
-        </li>
+        <NavItem key={item.path || item.label} item={item} level={level} location={location} />
       ))}
     </ul>
   );

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -3,9 +3,10 @@
 Reusable React components used across the application live in this directory.
 Currently it contains a `Header` component that renders the page title and a
 hierarchical navigation menu. The menu is hidden behind a dropdown and nested
-subpages have their own dropdowns so the structure is easy to follow. When the
-dropdown opens it appears on a white background that grows to fit whichever
-submenus are expanded. Links are separated by light borders and highlight on
- hover, and long page names wrap automatically within a 30rem-wide container. The
-`Header` accepts an optional `navItems` prop so tests can supply custom
-navigation lists.
+subpages can be revealed using small disclosure buttons to the left of each
+parent link. Each disclosure button toggles its submenu without preventing the
+link from being followed. When the dropdown opens it appears on a white
+background that grows to fit whichever submenus are expanded. Links are separated
+by light borders and highlight on hover, and long page names wrap automatically
+within a 30rem-wide container. The `Header` accepts an optional `navItems` prop
+so tests can supply custom navigation lists.

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -4,9 +4,11 @@ Reusable React components used across the application live in this directory.
 Currently it contains a `Header` component that renders the page title and a
 hierarchical navigation menu. The menu is hidden behind a dropdown and nested
 subpages can be revealed using small disclosure buttons to the left of each
-parent link. Each disclosure button toggles its submenu without preventing the
-link from being followed. When the dropdown opens it appears on a white
-background that grows to fit whichever submenus are expanded. Links are separated
-by light borders and highlight on hover, and long page names wrap automatically
-within a 30rem-wide container. The `Header` accepts an optional `navItems` prop
-so tests can supply custom navigation lists.
+parent link. The top level "Navigate" control also uses this left-hand
+disclosure triangle so the placement is consistent. Each disclosure button
+toggles its submenu without preventing the link from being followed. When the
+dropdown opens it appears on a white background that grows to fit whichever
+submenus are expanded. Links are separated by light borders and highlight on
+hover, and long page names wrap automatically within a 30rem-wide container.
+The `Header` accepts an optional `navItems` prop so tests can supply custom
+navigation lists.

--- a/src/index.css
+++ b/src/index.css
@@ -111,3 +111,21 @@ button:focus-visible {
 details[open] > summary.nav-summary::after {
   content: "\25BC"; /* upward triangle */
 }
+
+.nav-toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-right: 0.25rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+  line-height: 1;
+}
+
+.nav-toggle::before {
+  content: "\25B6";
+}
+
+.nav-toggle.open::before {
+  content: "\25BC";
+}

--- a/src/index.css
+++ b/src/index.css
@@ -92,24 +92,24 @@ button:focus-visible {
 
 .nav-summary {
   list-style: none;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  display: inline-flex;
+  align-items: center;
   cursor: pointer;
+  padding: 0;
 }
 
 .nav-summary::-webkit-details-marker {
   display: none;
 }
 
-.nav-summary::after {
-  content: "\25B6"; /* downward triangle */
+.nav-summary::before {
+  content: "\25B6"; /* closed triangle */
   font-size: 0.8rem;
-  margin-top: 0.125rem;
+  margin-right: 0.25rem;
 }
 
-details[open] > summary.nav-summary::after {
-  content: "\25BC"; /* upward triangle */
+details[open] > summary.nav-summary::before {
+  content: "\25BC"; /* open triangle */
 }
 
 .nav-toggle {

--- a/src/index.css
+++ b/src/index.css
@@ -122,6 +122,11 @@ details[open] > summary.nav-summary::before {
   line-height: 1;
 }
 
+.nav-toggle:focus,
+.nav-toggle:focus-visible {
+  outline: none;
+}
+
 .nav-toggle::before {
   content: "\25B6";
 }


### PR DESCRIPTION
## Summary
- allow nav tree toggling without swallowing page links
- style new `nav-toggle` buttons
- document updated header behaviour

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6883d49e8794832fa9e007bb956cd446