### PR TITLE
Randomized brick home page

### DIFF
--- a/src/__tests__/Home.test.jsx
+++ b/src/__tests__/Home.test.jsx
@@ -1,7 +1,6 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import Home from '../pages/Home.jsx';
+import { render, within } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
+import Home from '../pages/Home.jsx';
 
 function renderHome() {
   return render(
@@ -12,17 +11,14 @@ function renderHome() {
 }
 
 describe('Home page', () => {
-  it('increments click counter when button clicked', async () => {
-    renderHome();
-    const clickBtn = screen.getAllByText(/click me/i)[0];
-    await userEvent.click(clickBtn);
-    expect(screen.getByText(/you clicked the button 1 times/i)).toBeInTheDocument();
-  });
-
-  it('increments hover counter when hovered', async () => {
-    renderHome();
-    const hoverBtn = screen.getAllByText(/hover over me/i)[0];
-    await userEvent.hover(hoverBtn);
-    expect(screen.getByText(/you hovered over the other button 1 times/i)).toBeInTheDocument();
+  it('renders a link for each page', () => {
+    const { container } = renderHome();
+    const grid = container.querySelector('.brick-grid');
+    const utils = within(grid);
+    expect(utils.getByRole('link', { name: /about/i })).toBeInTheDocument();
+    expect(utils.getByRole('link', { name: /^reflection$/i })).toBeInTheDocument();
+    expect(utils.getByRole('link', { name: /^mirrors$/i })).toBeInTheDocument();
+    expect(utils.getByRole('link', { name: /concave mirrors/i })).toBeInTheDocument();
+    expect(utils.getByRole('link', { name: /convex mirrors/i })).toBeInTheDocument();
   });
 });

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import { Link, Outlet, useLocation } from "react-router-dom";
 import { useState } from "react";
+import NAV_ITEMS from "./navItems";
 
 function NavLink({ to, label, location }) {
   return (
@@ -53,30 +54,7 @@ function NavList({ items, level = 0, location }) {
   );
 }
 
-const DEFAULT_NAV_ITEMS = [
-  { path: "/", label: "Home" },
-  { path: "/about", label: "About" },
-  {
-    path: "/reflection",
-    label: "Reflection",
-    children: [
-      {
-        path: "/reflection/mirrors",
-        label: "Mirrors",
-        children: [
-          {
-            path: "/reflection/mirrors/concave-mirrors",
-            label: "Concave Mirrors",
-          },
-          {
-            path: "/reflection/mirrors/convex-mirrors",
-            label: "Convex Mirrors",
-          },
-        ],
-      },
-    ],
-  },
-];
+const DEFAULT_NAV_ITEMS = NAV_ITEMS;
 
 function Header({ title, navItems = DEFAULT_NAV_ITEMS }) {
   const location = useLocation();

--- a/src/components/navItems.js
+++ b/src/components/navItems.js
@@ -1,0 +1,26 @@
+const NAV_ITEMS = [
+  { path: '/', label: 'Home' },
+  { path: '/about', label: 'About' },
+  {
+    path: '/reflection',
+    label: 'Reflection',
+    children: [
+      {
+        path: '/reflection/mirrors',
+        label: 'Mirrors',
+        children: [
+          {
+            path: '/reflection/mirrors/concave-mirrors',
+            label: 'Concave Mirrors',
+          },
+          {
+            path: '/reflection/mirrors/convex-mirrors',
+            label: 'Convex Mirrors',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export default NAV_ITEMS;

--- a/src/index.css
+++ b/src/index.css
@@ -145,3 +145,20 @@ details[open] > summary.nav-summary::before {
 .nav-toggle.open::before {
   content: "\25BC";
 }
+
+.brick-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.brick {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 4rem;
+  font-weight: bold;
+  text-decoration: none;
+  border-radius: 4px;
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,22 +1,53 @@
-import { useState } from "react";
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
 import Header from "../components/Header";
+import NAV_ITEMS from "../components/navItems";
+
+function flatten(items) {
+  return items.reduce((acc, item) => {
+    if (item.path) {
+      acc.push({ path: item.path, label: item.label });
+    }
+    if (item.children) {
+      acc.push(...flatten(item.children));
+    }
+    return acc;
+  }, []);
+}
 
 function Home() {
-  const [count_click, setCountClick] = useState(0);
-  const [count_hover, setCountHover] = useState(0);
+  const bricks = useMemo(() => {
+    const pages = flatten(NAV_ITEMS).filter((p) => p.path !== "/");
+    for (let i = pages.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [pages[i], pages[j]] = [pages[j], pages[i]];
+    }
+    return pages.map((p) => {
+      const hue = Math.floor(Math.random() * 360);
+      const saturation = Math.floor(Math.random() * 40) + 60;
+      const lightness = Math.floor(Math.random() * 40) + 30;
+      return {
+        ...p,
+        bg: `hsl(${hue}, ${saturation}%, ${lightness}%)`,
+        color: lightness > 50 ? "#000" : "#fff",
+      };
+    });
+  }, []);
 
   return (
     <div>
       <Header title="Optics Tools" />
-      <div style={{ padding: "2rem" }}>
-        <p>You clicked the button {count_click} times</p>
-        <button onClick={() => setCountClick(count_click + 1)}>
-          Click me, hovering does nothing
-        </button>
-        <p>You hovered over the other button {count_hover} times</p>
-        <button onMouseOver={() => setCountHover(count_hover + 1)}>
-          Hover over me, clicks do nothing
-        </button>
+      <div className="brick-grid">
+        {bricks.map((b) => (
+          <Link
+            key={b.path}
+            to={b.path}
+            className="brick"
+            style={{ backgroundColor: b.bg, color: b.color }}
+          >
+            {b.label}
+          </Link>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- display page links as colorful bricks
- style bricks in a responsive grid
- export navigation items in a separate module
- update tests for new home page

## Testing
- `npm run lint`
- `npm test -- -t ""`

------
https://chatgpt.com/codex/tasks/task_e_6884023af77c832fba9a86e143f84d1d