### PR TITLE
Improve docs, lint config and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ It is built with [React](https://reactjs.org/) and [Vite](https://vitejs.dev/).
 - `npm run build` – create an optimized production build
 - `npm run preview` – preview the production build locally
 - `npm run lint` – run ESLint against the source code
+- `npm test` – run unit tests in watch mode
+- `npm run coverage` – generate a coverage report
 
 ## Project structure
 
@@ -29,3 +31,10 @@ npm run dev
 ```
 
 The application will be available at <http://localhost:5173> by default.
+
+To run the test suite once and generate coverage:
+
+```bash
+npm test -- --run
+npm run coverage
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'coverage']),
   {
     files: ['**/*.{js,jsx}'],
     extends: [

--- a/src/__tests__/Overview.test.jsx
+++ b/src/__tests__/Overview.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import Overview from '../components/Overview.jsx';
+
+describe('Overview', () => {
+  it('renders a heading and list items', () => {
+    const list = ['First', 'Second'];
+    render(<Overview list={list} />);
+    expect(screen.getByRole('heading', { name: /overview/i })).toBeInTheDocument();
+    list.forEach((text) => {
+      expect(screen.getByText(text)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/Reflection.test.jsx
+++ b/src/__tests__/Reflection.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Reflection from '../pages/Reflection/Reflection.jsx';
+
+function renderReflection() {
+  return render(
+    <BrowserRouter>
+      <Reflection />
+    </BrowserRouter>
+  );
+}
+
+describe('Reflection page', () => {
+  it('shows key facts about reflection', () => {
+    renderReflection();
+    expect(screen.getByRole('heading', { name: /overview/i })).toBeInTheDocument();
+    // check one or two known key facts
+    expect(
+      screen.getByText(/angle of reflection is equal to the angle of incidence/i)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- ignore coverage dir in eslint
- document test scripts in README
- show how to run coverage
- add unit tests for `Overview` component and `Reflection` page

## Testing
- `npm run lint`
- `npx vitest run`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_6884065fca2c832fb624cca3fd4ef719