### PR TITLE
Improve mobile layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,5 @@
 #root {
+  width: 100%;
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;

--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,9 @@
 .read-the-docs {
   color: #888;
 }
+
+@media (max-width: 600px) {
+  #root {
+    padding: 1rem;
+  }
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -71,7 +71,7 @@ function Header({ title, navItems = DEFAULT_NAV_ITEMS }) {
       <div
         style={{
           position: "relative",
-          width: "100vw",
+          width: "100%",
           backgroundColor: "var(--color-header-bg)",
           paddingTop: "1rem",
           paddingBottom: "0.5rem",

--- a/src/index.css
+++ b/src/index.css
@@ -189,3 +189,21 @@ details[open] > summary.nav-summary::before {
   padding-left: 5rem;
   width: 75%;
 }
+
+@media (max-width: 600px) {
+  .page_content {
+    padding-top: 1rem;
+    padding-left: 1rem;
+    width: 100%;
+  }
+
+  .brick-grid {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 0.5rem;
+    padding: 0.5rem;
+  }
+
+  .overview {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak #root padding on small screens
- update Header to use percentage width
- add responsive styles for pages, bricks, and overview

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6884346af838832f9de0570522f9f5f4